### PR TITLE
Update runtime to node 12

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: nestjs-serverless
 
 provider:
   name: aws
-  runtime: nodejs10.x
+  runtime: nodejs12.x
 
 plugins:
   - serverless-domain-manager


### PR DESCRIPTION
### Changes:
- Update `nodejs` runtime for `aws lambda`.

### Notes:
Merging this because it's already deployed to `AWS`.